### PR TITLE
add 1.x versions of SpecialFunctions.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "GaussQuadrature"
 uuid = "d54b0c1a-921d-58e0-8e36-89d8069c0969"
-version = "0.5.4"
 author = ["William McLean <w.mclean@unsw.edu.au>"]
+version = "0.5.4"
 
 [deps]
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
+SpecialFunctions = "0.8, 0.9, 0.10, 1.0"
 julia = "1.2.0"
-SpecialFunctions = "0.8, 0.9, 0.10"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GaussQuadrature"
 uuid = "d54b0c1a-921d-58e0-8e36-89d8069c0969"
 author = ["William McLean <w.mclean@unsw.edu.au>"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"


### PR DESCRIPTION
It would be nice to allow the 1.x branch of SpecialFunctions. The GaussQuadrature package currently stops this package from upgrading on my system.

The test suite completed successfully with SpecialFunctions 1.2.1 on my setup.