### PR TITLE
Make endpt=both exact

### DIFF
--- a/src/GaussQuadrature.jl
+++ b/src/GaussQuadrature.jl
@@ -467,7 +467,8 @@ function custom_gauss_rule(lo::T, hi::T,
     # Ensure end point values are exact.
     if endpt in (left, both)
         a[idx[1]] = lo
-    elseif endpt in (right, both)
+    end
+    if endpt in (right, both)
         a[idx[n]] = hi 
     end
     return a[idx], w[idx]

--- a/test/test_legendre.jl
+++ b/test/test_legendre.jl
@@ -1,6 +1,12 @@
 correct = ( pi/4 + atan(3.0) ) / 2
 for endpt in [neither, both, left, right]
     x, w = legendre(40, endpt)
+    if endpt in [left, both]
+        @test x[1] == -1
+    end
+    if endpt in [right, both]
+        @test x[end] == 1
+    end
     Q = sum(w .* 1 ./ ( 1 .+ (2x .- 1).^2))
     @test Q ≈ correct
 end


### PR DESCRIPTION
The elseif statement meant that endpt=both wasn't exact on the right interval.